### PR TITLE
feat: add toggle switch component

### DIFF
--- a/packages/demosite/src/Home.js
+++ b/packages/demosite/src/Home.js
@@ -10,7 +10,7 @@ import Checkbox from 'nanoether/Checkbox'
 import UIContext from 'nanoether/interface'
 import Textfield from 'nanoether/Textfield'
 import Stepper from 'nanoether/Stepper'
-import Toggle from 'nanoether/ToggleSwitch'
+import Toggle from 'nanoether/Toggle'
 
 const Spacer = () => <div style={{ width: '8px', height: '8px' }} />
 

--- a/packages/demosite/src/Home.js
+++ b/packages/demosite/src/Home.js
@@ -10,6 +10,7 @@ import Checkbox from 'nanoether/Checkbox'
 import UIContext from 'nanoether/interface'
 import Textfield from 'nanoether/Textfield'
 import Stepper from 'nanoether/Stepper'
+import Toggle from 'nanoether/ToggleSwitch'
 
 const Spacer = () => <div style={{ width: '8px', height: '8px' }} />
 
@@ -20,6 +21,8 @@ export default observer(() => {
   const [text, setText] = React.useState('')
   const [enteredText, setEnteredText] = React.useState('')
   const [step, setStep] = React.useState(1)
+  const [isOn, setIsOn] = React.useState(false)
+  const [isOn2, setIsOn2] = React.useState(false)
   return (
     <div className={`container ${ui.modeCssClass}`}>
       <div className={`header ${ui.modeCssClass}`}>
@@ -170,6 +173,21 @@ export default observer(() => {
             </div>
             <div style={{ marginBottom: '12px' }}>
               <Stepper size="xlarge" />
+            </div>
+          </div>
+        </ExampleSection>
+        <ExampleSection name="Toggle Switch">
+          <div style={{ flexDirection: 'column' }}>
+            <div style={{ marginBottom: '12px', display: 'flex', alignItems: 'center' }}>
+              <Toggle onChange={setIsOn} id="toggle-sample1" />
+              <span style={{ marginLeft: '8px' }}> uncontrolled toggle {isOn ? 'on' : 'off'}</span>
+            </div>
+            <div style={{ marginBottom: '12px', display: 'flex', alignItems: 'center' }}>
+              <Toggle checked={isOn2} onChange={setIsOn2} id="toggle-sample2" />
+              <Button style={{ marginLeft: '8px' }} size="xsmall" onClick={() => setIsOn2(!isOn2)}>
+                button to toggle
+              </Button>
+              {isOn2 ? 'on' : 'off'}
             </div>
           </div>
         </ExampleSection>

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -120,15 +120,14 @@ return (
 A toggle switch component
 
 Props:
-  - `id: string`: Identifier of the toggle switch.
   - `onChange: Optional<(boolean) => void>`: Change event handler.
   - `checked: Optional<boolean>`: To make switch controlled field.
 
 ```jsx
-import Toggle from 'nanoether/ToggleSwitch'
+import Toggle from 'nanoether/Toggle'
 
 return (
-  <Toggle id="some-toggle-switch" onChange={setIsOn} checked={isOn} />
+  <Toggle onChange={setIsOn} checked={isOn} />
 )
 
 ```

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -115,6 +115,24 @@ return (
 )
 ```
 
+### Toggle Switch
+
+A toggle switch component
+
+Props:
+  - `id: string`: Identifier of the toggle switch.
+  - `onChange: Optional<(boolean) => void>`: Change event handler.
+  - `checked: Optional<boolean>`: To make switch controlled field.
+
+```jsx
+import Toggle from 'nanoether/ToggleSwitch'
+
+return (
+  <Toggle id="some-toggle-switch" onChange={setIsOn} checked={isOn} />
+)
+
+```
+
 ## Contexts
 
 ### Interface

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -12,7 +12,7 @@
     "./Tooltip": "./src/Tooltip.js",
     "./Checkbox": "./src/Checkbox.js",
     "./Stepper": "./src/Stepper.js",
-    "./ToggleSwitch": "./src/ToggleSwitch.js",
+    "./Toggle": "./src/Toggle.js",
     "./interface": "./src/contexts/interface.js",
     "./colors.css": "./src/colors.css"
   },

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -12,6 +12,7 @@
     "./Tooltip": "./src/Tooltip.js",
     "./Checkbox": "./src/Checkbox.js",
     "./Stepper": "./src/Stepper.js",
+    "./ToggleSwitch": "./src/ToggleSwitch.js",
     "./interface": "./src/contexts/interface.js",
     "./colors.css": "./src/colors.css"
   },

--- a/packages/kit/src/Toggle.js
+++ b/packages/kit/src/Toggle.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import './toggleswitch.css'
+import './toggle.css'
 import UIContext from './contexts/interface'
 
 const ToggleSwitch = ({ onChange, checked, ...props }) => {
@@ -9,12 +9,13 @@ const ToggleSwitch = ({ onChange, checked, ...props }) => {
     <input
       className={`nanoether--toggle ${ui.modeCssClass}`}
       type="checkbox"
-      checked={typeof checked === 'boolean' ? checked : undefined}
+      checked={checked}
       onChange={(e) => {
         if (onChange) {
           onChange(e.target.checked)
         }
       }}
+      {...props}
     />
   )
 }

--- a/packages/kit/src/ToggleSwitch.js
+++ b/packages/kit/src/ToggleSwitch.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import './toggleswitch.css'
+import UIContext from './contexts/interface'
+
+const ToggleSwitch = ({ onChange, checked, id, ...props }) => {
+  const ui = React.useContext(UIContext)
+
+  return (
+    <div className={ui.modeCssClass}>
+      <input
+        id={id}
+        className="nanoether--toggle"
+        type="checkbox"
+        checked={typeof checked === 'boolean' ? checked : undefined}
+        onChange={(e) => {
+          if (onChange) {
+            onChange(e.target.checked)
+          }
+        }}
+      />
+      <label htmlFor={id} />
+    </div>
+  )
+}
+
+export default ToggleSwitch

--- a/packages/kit/src/toggle.css
+++ b/packages/kit/src/toggle.css
@@ -23,14 +23,13 @@ input[type='checkbox'].nanoether--toggle:before {
   height: 26px;
   background-color: var(--color-gray-9);
   border-radius: 50%;
-  top: 3px;
+  top: 2px;
   left: 4px;
 }
 
 /* checked style */
 input[type='checkbox'].nanoether--toggle:checked {
   background-color: var(--color-gray-9);
-  /* border-color: var(--color-white); */
 }
 
 input[type='checkbox'].nanoether--toggle:checked:before {
@@ -46,7 +45,6 @@ input[type='checkbox'].nanoether--toggle.dark {
 
 input[type='checkbox'].nanoether--toggle.dark:checked {
   background-color: var(--color-white);
-  /* border-color: var(--color-gray-9); */
 }
 
 input[type='checkbox'].nanoether--toggle.dark:before {

--- a/packages/kit/src/toggleswitch.css
+++ b/packages/kit/src/toggleswitch.css
@@ -1,0 +1,60 @@
+input[type='checkbox'].nanoether--toggle {
+  display: none;
+}
+
+input[type='checkbox'].nanoether--toggle + label {
+  display: flex;
+  width: 52px;
+  height: 32px;
+  border: 1px solid var(--color-gray-9);
+  border-radius: 99em;
+  position: relative;
+  transition: all 0.25s ease;
+  transform-origin: 50% 50%;
+  background-color: var(--color-white);
+  cursor: pointer;
+}
+
+input[type='checkbox'].nanoether--toggle + label:before {
+  transition: all 0.25s ease;
+  transition-delay: 0.05s;
+  content: '';
+  display: block;
+  position: absolute;
+  width: 26px;
+  height: 26px;
+  background-color: var(--color-gray-9);
+  border-radius: 50%;
+  top: 3px;
+  left: 4px;
+}
+
+/* checked style */
+input[type='checkbox'].nanoether--toggle:checked + label {
+  background-color: var(--color-gray-9);
+  border-color: var(--color-white);
+}
+
+input[type='checkbox'].nanoether--toggle:checked + label:before {
+  transform: translateX(18px);
+  background-color: var(--color-white);
+}
+
+/* dark theme */
+.dark > input[type='checkbox'].nanoether--toggle + label {
+  border-color: var(--color-white);
+  background-color: var(--color-gray-9);
+}
+
+.dark > input[type='checkbox'].nanoether--toggle + label:before {
+  background-color: var(--color-white);
+}
+
+.dark > input[type='checkbox'].nanoether--toggle:checked + label {
+  background-color: var(--color-white);
+  border-color: var(--color-gray-9);
+}
+
+.dark > input[type='checkbox'].nanoether--toggle:checked + label:before {
+  background-color: var(--color-gray-9);
+}


### PR DESCRIPTION
Added a toggle switch component.
I'm not very fun of having `id` as a prop, but we need to have id hook like [this](https://github.com/facebook/react/pull/22644) to omit that. For now, I think it's okay to have `id` prop for simplicity.

close #18 